### PR TITLE
Refactor OSD flight mode logic

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1012,24 +1012,15 @@ static bool osdDrawSingleElement(uint8_t item)
         {
             char *p = "ACRO";
 
-            if (isAirmodeActive()) {
-                p = "AIR ";
-            }
-
-            if (FLIGHT_MODE(FAILSAFE_MODE)) {
+            if (FLIGHT_MODE(FAILSAFE_MODE))
                 p = "!FS!";
-            } else if (FLIGHT_MODE(MANUAL_MODE)) {
+            else if (FLIGHT_MODE(MANUAL_MODE))
                 p = "MANU";
-            } else if (FLIGHT_MODE(NAV_RTH_MODE)) {
+            else if (FLIGHT_MODE(NAV_RTH_MODE))
                 p = "RTH ";
-            } else if (FLIGHT_MODE(NAV_POSHOLD_MODE)) {
-                if (FLIGHT_MODE(NAV_ALTHOLD_MODE)) {
-                    // 3D HOLD
-                    p = "HOLD";
-                } else {
-                    p = " PH ";
-                }
-            } else if (FLIGHT_MODE(NAV_ALTHOLD_MODE) && navigationRequiresAngleMode()) {
+            else if (FLIGHT_MODE(NAV_POSHOLD_MODE))
+                p = "HOLD";
+            else if (FLIGHT_MODE(NAV_ALTHOLD_MODE) && navigationRequiresAngleMode()) {
                 // If navigationRequiresAngleMode() returns false when ALTHOLD is active,
                 // it means it can be combined with ANGLE, HORIZON, ACRO, etc...
                 // and its display is handled by OSD_MESSAGES rather than OSD_FLYMODE.
@@ -1040,6 +1031,8 @@ static bool osdDrawSingleElement(uint8_t item)
                 p = "ANGL";
             else if (FLIGHT_MODE(HORIZON_MODE))
                 p = "HOR ";
+            else if (isAirmodeActive())
+                p = "AIR ";
 
             displayWrite(osdDisplayPort, elemPosX, elemPosY, p);
             return true;


### PR DESCRIPTION
As of 2.0.0 POSHOLD always includes ALTHOLD, so remove that unused legacy logic.  Also reformatted as per coding style.